### PR TITLE
force bump tldrwl version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pytube~=12.1
 pytz~=2022.6
 redis~=3.5
 sqlalchemy~=2.0.0b3
-tldrwl>=1.0.0,<2.0.0
+tldrwl>=1.1.1,<2.0.0
 
 # Additional requirements for web
 quart~=0.18


### PR DESCRIPTION
I'm pretty sure the version of the package isn't being bumped. From reading online, if there is a local / cached version that satisfies the requirements, the latest version won't be downloaded. So I'm guessing there's a cache somewhere with the older version.