### PR TITLE
[AI generated] Add ThanksNudgeHandler to remind users to use !thanks when they say thanks

### DIFF
--- a/dicebot/core/guild_context.py
+++ b/dicebot/core/guild_context.py
@@ -25,6 +25,7 @@ from dicebot.handlers.message.long_message_handler import LongMessageHandler
 from dicebot.handlers.message.shame_handler import ShameHandler
 from dicebot.handlers.message.tldrwl_handler import TldrwlHandler
 from dicebot.handlers.message.youtube_handler import YoutubeHandler
+from dicebot.handlers.message.thanks_nudge_handler import ThanksNudgeHandler
 
 # on_reaction handlers
 from dicebot.handlers.reaction.ban_handler import BanReactionHandler
@@ -72,6 +73,7 @@ class GuildContext:
             FoolHandler(),
             ShameHandler(),
             YoutubeHandler(),
+            ThanksNudgeHandler(),
             # These can be slow, so keep them at the end of the list
             TldrwlHandler(),
             PunHandler(),

--- a/dicebot/handlers/message/test_thanks_nudge_handler.py
+++ b/dicebot/handlers/message/test_thanks_nudge_handler.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+from unittest.mock import AsyncMock
+
+from dicebot.handlers.message.thanks_nudge_handler import ThanksNudgeHandler
+from dicebot.test.utils import TestMessageContext, DicebotTestCase
+
+
+class TestThanksNudgeHandler(DicebotTestCase):
+    async def test_should_handle_when_thanks_present(self):
+        ctx = TestMessageContext.get("Thanks for your help!")
+        handler = ThanksNudgeHandler()
+        self.assertTrue(await handler.should_handle(ctx))
+
+    async def test_should_not_handle_for_commands(self):
+        ctx = TestMessageContext.get("!thanks @user Great job")
+        handler = ThanksNudgeHandler()
+        self.assertFalse(await handler.should_handle(ctx))
+
+    async def test_should_not_handle_if_no_thanks(self):
+        ctx = TestMessageContext.get("hello world")
+        handler = ThanksNudgeHandler()
+        self.assertFalse(await handler.should_handle(ctx))
+
+    async def test_handle_sends_nudge(self):
+        ctx = TestMessageContext.get("thanks bot")
+        ctx.send = AsyncMock()
+        handler = ThanksNudgeHandler()
+        await handler.handle(ctx)
+        expected = f"{ctx.author.as_mention()} Please use `!thanks` to publicly record your thanks!"
+        ctx.send.assert_called_once_with(expected)

--- a/dicebot/handlers/message/thanks_nudge_handler.py
+++ b/dicebot/handlers/message/thanks_nudge_handler.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import re
+from dicebot.handlers.message.abstract_handler import AbstractHandler
+from dicebot.data.types.message_context import MessageContext
+
+THANKS_REGEX = re.compile(r"\bthanks\b", re.IGNORECASE)
+
+class ThanksNudgeHandler(AbstractHandler):
+    """Nudge users to use !thanks when they say thanks in chat."""
+
+    async def should_handle(self, ctx: MessageContext) -> bool:
+        content = ctx.message.content
+        if not content:
+            return False
+        # Ignore commands
+        if content.startswith("!"):
+            return False
+        # Only in guild channels
+        if ctx.message.guild is None:
+            return False
+        return bool(THANKS_REGEX.search(content))
+
+    async def handle(self, ctx: MessageContext) -> None:
+        user_mention = ctx.author.as_mention()
+        await ctx.send(f"{user_mention} Please use `!thanks` to publicly record your thanks!")


### PR DESCRIPTION
This PR adds a new message handler (ThanksNudgeHandler) that detects when someone says ‘thanks’ in chat and gently reminds them to use the `!thanks` command. It also includes unit tests for the new handler.